### PR TITLE
Make sure res/snd files are provisioned

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include requirements.txt
 include LICENSE.md
+include ovos_listener/res/snd/start_listening.wav
+include ovos_listener/res/snd/acknowledge.mp3
+include ovos_listener/res/snd/error.mp3


### PR DESCRIPTION
These audio files are not currently provisioned by `pip`.
```
ovos_listener/res/snd/start_listening.wav
ovos_listener/res/snd/acknowledge.mp3
ovos_listener/res/snd/error.mp3
```