### PR TITLE
Update ovos-backend-client dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ ovos-utils~=0.0, >=0.0.31
 ovos-bus-client>=0.0.3a16,~=0.0
 ovos-plugin-manager~=0.0, >=0.0.23
 ovos-config~=0.0,>=0.0.8
-ovos_backend_client~=0.0, >=0.0.7
+ovos_backend_client~=0.0, >=0.0.6


### PR DESCRIPTION
0.0.7 was not a valid release, should be 0.0.6
Addressing https://github.com/OpenVoiceOS/ovos-core/pull/448 test failure